### PR TITLE
Fixes divide by zero error in spectrogram code

### DIFF
--- a/src/transform/+mag/+transform/Spectrogram.m
+++ b/src/transform/+mag/+transform/Spectrogram.m
@@ -79,6 +79,8 @@ classdef Spectrogram < mag.transform.Transformation
 
                     k = ceil(height(field) / 100);
                     field = (field - movmean(field, k, "omitmissing")) ./ movstd(field, k, "omitmissing");
+                    idx = isnan(field); % ISNAN identifies where 0/0 has occurred above
+                    field(idx) = 0;
                 end
             end
 


### PR DESCRIPTION
Quick fix to correct for divide by zero error when `movstd` is zero, during normalisation before computing a spectrogram. 

Replaces `NaN` values (which occur when the moving mean, and the moving standard deviation are both zero, resulting in 0/0), with zero in the field. This can occur when the data is of very poor resolution, and therefore has the same value continuously over the period the moving mean and moving standard deviation are computed. 

Open to other solutions, but I think replacing the NaN values with 0 is in the spirit of the normalisation, given the values are equal to the mean. 

Closes #63 